### PR TITLE
Add LogBERT & KnowLog embedding modules

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -53,3 +53,5 @@ openTSNE>=0.5.0
 
 # Progress spinners
 halo>=0.0.31
+torch>=2.0.0
+transformers>=4.38.0

--- a/src/compare_embedding_performance.py
+++ b/src/compare_embedding_performance.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python3
+"""Compare classification performance of FastText, LogBERT and KnowLog embeddings."""
+
+from pathlib import Path
+import pickle
+
+import numpy as np
+from sklearn.linear_model import LogisticRegression
+from sklearn.metrics import f1_score
+from sklearn.model_selection import train_test_split
+
+EMB_DIR = Path("embeddings")
+
+
+def load_embedding(path_prefix: Path):
+    with open(path_prefix / "log_embeddings.pkl", "rb") as f:
+        X = pickle.load(f)
+    with open(path_prefix / "labels.json", "r") as f:
+        y = pickle.load(f)
+    if not isinstance(X, np.ndarray):
+        X = np.array(X)
+    return X, y
+
+
+def evaluate(name: str, X: np.ndarray, y):
+    X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.2, random_state=42, stratify=y)
+    model = LogisticRegression(max_iter=200)
+    model.fit(X_train, y_train)
+    preds = model.predict(X_test)
+    score = f1_score(y_test, preds, average="weighted")
+    print(f"{name} F1-score: {score:.4f}")
+    return score
+
+
+def main():
+    results = {}
+    for name in ["fasttext", "Spark_Log_Analysis-logbert", "knowlog-bert"]:
+        prefix = EMB_DIR / name if name != "fasttext" else EMB_DIR
+        try:
+            X, y = load_embedding(prefix)
+        except FileNotFoundError:
+            print(f"Embeddings for {name} not found, skipping")
+            continue
+        results[name] = evaluate(name, X, y)
+    with open("results/embedding_comparison.json", "w") as f:
+        import json
+        json.dump(results, f, indent=2)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/logbert_knowlog_embedding.py
+++ b/src/logbert_knowlog_embedding.py
@@ -1,0 +1,116 @@
+#!/usr/bin/env python3
+"""Generate log embeddings using LogBERT and KnowLog models.
+
+This script loads processed TFRecord logs, fine-tunes the chosen model
+with a masked language modeling objective (self-supervised), then
+extracts embeddings for each log entry.
+"""
+
+from pathlib import Path
+import json
+import pickle
+from typing import List
+
+import numpy as np
+import tensorflow as tf
+import torch
+from transformers import (
+    AutoTokenizer,
+    AutoModelForMaskedLM,
+    DataCollatorForLanguageModeling,
+    Trainer,
+    TrainingArguments,
+)
+
+PROCESSED_DIR = Path("processed")
+OUTPUT_DIR = Path("embeddings")
+BATCH_SIZE = 16
+EPOCHS = 1
+
+
+def parse_example(example_proto):
+    feature_description = {
+        "l": tf.io.FixedLenFeature([], tf.string),
+        "y": tf.io.FixedLenFeature([], tf.string),
+    }
+    example = tf.io.parse_single_example(example_proto, feature_description)
+    return example["l"], example["y"]
+
+
+def load_logs() -> List[str]:
+    tfrecord_files = list(PROCESSED_DIR.glob("**/*.tfrecord"))
+    if not tfrecord_files:
+        raise FileNotFoundError("No TFRecord files found in 'processed' directory")
+
+    dataset = tf.data.TFRecordDataset(tfrecord_files, compression_type="GZIP")
+    dataset = dataset.map(parse_example)
+
+    logs = [log.numpy().decode("utf-8") for log, _ in dataset]
+    labels = [label.numpy().decode("utf-8") for _, label in dataset]
+    return logs, labels
+
+
+def fine_tune_model(model_name: str, texts: List[str]) -> AutoModelForMaskedLM:
+    tokenizer = AutoTokenizer.from_pretrained(model_name)
+    model = AutoModelForMaskedLM.from_pretrained(model_name)
+
+    tokens = tokenizer(texts, truncation=True, padding=True)
+    tf_dataset = tf.data.Dataset.from_tensor_slices(tokens)
+
+    collator = DataCollatorForLanguageModeling(tokenizer=tokenizer, mlm=True)
+    training_args = TrainingArguments(
+        output_dir="tmp_finetune",
+        per_device_train_batch_size=BATCH_SIZE,
+        num_train_epochs=EPOCHS,
+        logging_steps=10,
+        learning_rate=5e-5,
+    )
+    trainer = Trainer(
+        model=model,
+        args=training_args,
+        train_dataset=tf_dataset,
+        data_collator=collator,
+    )
+    trainer.train()
+    return tokenizer, model
+
+
+def embed_logs(tokenizer, model, texts: List[str]) -> np.ndarray:
+    embeddings = []
+    model.eval()
+    with torch.no_grad():
+        for i in range(0, len(texts), BATCH_SIZE):
+            batch = texts[i : i + BATCH_SIZE]
+            tokens = tokenizer(batch, padding=True, truncation=True, return_tensors="pt")
+            outputs = model(**tokens, output_hidden_states=True)
+            hidden = outputs.hidden_states[-1].mean(dim=1)
+            embeddings.append(hidden.cpu().numpy())
+    return np.vstack(embeddings)
+
+
+def process_model(model_name: str, logs: List[str], labels: List[str]):
+    print(f"Processing {model_name} ...")
+    tokenizer, model = fine_tune_model(model_name, logs)
+    vectors = embed_logs(tokenizer, model, logs)
+
+    out_dir = OUTPUT_DIR / model_name.split("/")[-1]
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    with open(out_dir / "log_embeddings.pkl", "wb") as f:
+        pickle.dump(vectors, f)
+    with open(out_dir / "labels.json", "w") as f:
+        json.dump(labels, f)
+    print(f"Saved embeddings to {out_dir}")
+
+
+def main():
+    logs, labels = load_logs()
+    for model in ["Sirapatsorn/Spark_Log_Analysis-logbert", "deeperbreath/knowlog-bert"]:
+        try:
+            process_model(model, logs, labels)
+        except Exception as exc:
+            print(f"Failed to process {model}: {exc}")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/unsupervised_transformer_labeling.py
+++ b/src/unsupervised_transformer_labeling.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python3
+"""Unsupervised log labelling using a transformer encoder.
+
+Logs are embedded with a pre-trained sentence-transformer model and
+clustered with KMeans. Cluster assignments are mapped to the majority
+true label for evaluation.
+"""
+
+from pathlib import Path
+import json
+import pickle
+from typing import List
+
+import numpy as np
+from sklearn.cluster import KMeans
+from sklearn.metrics import f1_score
+from transformers import AutoTokenizer, AutoModel
+import torch
+import tensorflow as tf
+
+PROCESSED_DIR = Path("processed")
+BATCH_SIZE = 32
+MODEL_NAME = "sentence-transformers/all-MiniLM-L6-v2"
+
+
+def parse_example(example_proto):
+    feature_description = {"l": tf.io.FixedLenFeature([], tf.string), "y": tf.io.FixedLenFeature([], tf.string)}
+    example = tf.io.parse_single_example(example_proto, feature_description)
+    return example["l"], example["y"]
+
+
+def load_data() -> tuple[list[str], list[str]]:
+    tfrecord_files = list(PROCESSED_DIR.glob("**/*.tfrecord"))
+    if not tfrecord_files:
+        raise FileNotFoundError("No TFRecord files found")
+    ds = tf.data.TFRecordDataset(tfrecord_files, compression_type="GZIP").map(parse_example)
+    logs = [l.numpy().decode("utf-8") for l, _ in ds]
+    labels = [y.numpy().decode("utf-8") for _, y in ds]
+    return logs, labels
+
+
+def embed_texts(texts: List[str]) -> np.ndarray:
+    tokenizer = AutoTokenizer.from_pretrained(MODEL_NAME)
+    model = AutoModel.from_pretrained(MODEL_NAME)
+    embeddings = []
+    model.eval()
+    with torch.no_grad():
+        for i in range(0, len(texts), BATCH_SIZE):
+            batch = texts[i : i + BATCH_SIZE]
+            tokens = tokenizer(batch, padding=True, truncation=True, return_tensors="pt")
+            output = model(**tokens)
+            vec = output.last_hidden_state.mean(dim=1)
+            embeddings.append(vec.cpu().numpy())
+    return np.vstack(embeddings)
+
+
+def main():
+    logs, labels = load_data()
+    vectors = embed_texts(logs)
+    n_clusters = len(set(labels)) or 2
+    kmeans = KMeans(n_clusters=n_clusters, n_init=10, random_state=42)
+    cluster_ids = kmeans.fit_predict(vectors)
+
+    # map cluster -> majority true label
+    mapping = {}
+    for cid in range(n_clusters):
+        indices = [i for i, c in enumerate(cluster_ids) if c == cid]
+        true = [labels[i] for i in indices]
+        if true:
+            mapping[cid] = max(set(true), key=true.count)
+        else:
+            mapping[cid] = "unknown"
+    pred_labels = [mapping[c] for c in cluster_ids]
+    score = f1_score(labels, pred_labels, average="weighted")
+    print(f"Unsupervised F1-score: {score:.4f}")
+
+    with open("results/unsupervised_labeling_score.txt", "w") as f:
+        f.write(str(score))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add LogBERT and KnowLog self‑supervised embedding generation script
- add unsupervised transformer based log labelling
- provide comparison utility for FastText vs LogBERT vs KnowLog
- include transformer deps

## Testing
- `python -m py_compile src/logbert_knowlog_embedding.py src/unsupervised_transformer_labeling.py src/compare_embedding_performance.py`


------
https://chatgpt.com/codex/tasks/task_e_6856213d7e7c83218e7555d97885ffd6